### PR TITLE
Updating Compilation files.

### DIFF
--- a/macos_f90/Make-Linux-x86_64.T
+++ b/macos_f90/Make-Linux-x86_64.T
@@ -38,16 +38,15 @@ LOCAL_CFLAGS += -DSVN_REV="\"$(SVN_REV)\""
 
 ################################################################################
 # Libraries for MACOS:
-
-MLIBS = /opt/intel-$(intel_version)/lib/intel64/libimf.a \
-        /opt/intel-$(intel_version)/lib/intel64/libifport.a \
-        /opt/intel-$(intel_version)/lib/intel64/libifcore.a \
+MLIBS = $(intel64_lib)/libimf.a \
+        $(intel64_lib)/libifport.a \
+        $(intel64_lib)/libifcore.a \
         -L/usr/lib64 -lX11 \
         -L$(SRC_DIR)/pgplot -lpgplot \
         -L$(SRC_DIR)/fits_build -lfits \
         $(RL_LIBS)
 
-NPSOL_ROOT=$(SRC_DIR)/npsol
+NPSOL_ROOT=$(macossrc_dir)/npsol
 NPSOL_OBJS=$(NPSOL_ROOT)/blas/blas.o $(NPSOL_ROOT)/lapack/lapack.o \
             $(NPSOL_ROOT)/Linux-x86_64/npsol.o
 ###############################################################################
@@ -58,7 +57,7 @@ $(macosexe): $(MACOSOBJS)
 	$(FC) $(LDFLAGS) -o $@ $(NPSOL_OBJS) $(MACOSOBJS) $(MLIBS)
 
 
-SMDRVLIBS = -L/opt/intel/composer_xe_2011_sp1.8.273/compiler/lib/intel64 -limf -lintlc -lifport -lifcore -lc -lm \
+SMDRVLIBS = -L$intel64_lib -limf -lintlc -lifport -lifcore -lc -lm \
             -L/usr/lib64 -lX11
 
 # SMACOS library

--- a/makefile_all.sh
+++ b/makefile_all.sh
@@ -2,21 +2,60 @@
 ## exit on the first error.
 set -e
 
-# source intel iccvars file which will be used to compile all libraries
-# source /opt/intel-$intel_version/bin/compilervars.sh intel64
-source /opt/intel-14.0.0/oneapi/setvars.sh intel64 --force
+#--------------------------------------------------------------------------
+#--------------------------------------------------------------------------
+## Compilation Instructions
+#
+# Instructions to compile MACOS, SMACOS, and necessary libraries such as 
+# npsol, pgplot, and readline. Assumption is user has cd to the MACOS folder.
+# Here we set some global variable which can serve as reference inside
+# the Makefile to avoid the need for user to change or hack the MACOS 
+# Makefile.
+#
+# To Compile:
+#
+#   1. Setup Environment
+#   2. Setup MACOS source path with pwd
+#   3. Compile npsol
+#   4. Compile pgplot
+#   5. Compile readline-8.2
+#   6. Compile macos
+#   7. Compile smacos
+#   8. Compile GMI
 
-#export LD_LIBRARY_PATH=/opt/intel/oneapi/mkl/latest/lib/intel64
-export LD_LIBRARY_PATH=/opt/intel-14.0.0/oneapi/compiler/2023.1.0/linux/compiler/lib/intel64
+#-----------------------------------------------------------------------------
+# 1. Set up environment
+# 
+#  Note: User must set the version of the Intel Compiler being used. User may
+#  also need to tinker with Intel Compiler path here because the path to
+#  compiler depends on the setup of the Intel Compiler by Admin. In this case
+#  we are using oneAPI which requires oneAPI folder inside inte-$intel_version
+#  to source oneAPI Intel Compiler variables.
+#------------------------------------------------------------------------------
+export intel_version=14.0.0
+export intel64_lib=/opt/intel-$intel_version/oneapi/compiler/2023.1.0/linux/compiler/lib/intel64_lin
+source /opt/intel-$intel_version/oneapi/setvars.sh intel64 --force
 
-export LD_LIBRARY_PATH=/home/lmarchen/MACOS/work/git_macos/macos-develop2/macos_f90/pgplot
-export PGPLOT_FONT=/home/lmarchen/MACOS/work/git_macos/macos-develop2/macos_f90/pgplot/grfont.dat
-export PGPLOT_DIR=/home/lmarchen/MACOS/work/git_macos/macos-develop2/macos_f90/pgplot
-export LD_LIBRARY_PATH=/home/lmarchen/MACOS/work/git_macos/macos-develop2/macos_f90/readline-8.2
-export LD_LIBRARY_PATH=/opt/intel-14.0.0/oneapi/compiler/2023.1.0/linux/compiler/lib/intel64
-
-
+#------------------------------------------------------------------------------------------------------
+# 2. Setup MACOS source path with pwd, and Matlab path
+#
+# The user should add the source line above, and the export lines below to 
+# their .aliases or .bashrc file:
+#
+#  1. export PGPLOT_FONT=$macossrc_dir/grfont.dat
+#  2. export PGPLOT_DIR=$macossrc_dir/pgplot
+#  3. export LD_LIBRARY_PATH=$macossrc_dir/readline-8.2
+#  4. export LD_LIBRARY_PATH=$intel64_lib
+#------------------------------------------------------------------------------------------------------
 cd macos_f90
+# Our source files are in the current directory
+export macossrc_dir=$(pwd)
+export matlab_version=$(which matlab)
+
+export PGPLOT_FONT=$macossrc_dir/grfont.dat
+export PGPLOT_DIR=$macossrc_dir/pgplot
+export LD_LIBRARY_PATH=$macossrc_dir/readline-8.2
+export LD_LIBRARY_PATH=$intel64_lib
 
 #--------------------------------------------------------------------------
 # Compile npsol library (can be compiled with gfortran or ifort)
@@ -81,22 +120,20 @@ make smacos
 #
 # Note:
 #
-# 1. User must change text /home/lmarchen/MACOS/work/git_macos/macos-develop2
-#    to user's local path to macos source code
-# 2. User must change /usr/local/MATLAB/R2023b if using different version of
-#    Matlab to compile GMI or if location of Matlab is different
-# 3. User must change /opt/intel-14.0.0/oneapi/compiler/2023.1.0/linux/compiler/lib/intel64_lin 
-#    if using a different version of the compiler or if different from it.
+# 1. User must change matlab_version above, or leave it as is if matlab
+#    has been setup as /usr/local/bin/matlab
+#
 #-------------------------------------------------------------------------
-cd ../GMI
+cd ../../GMI
+make clean
+make
 
 
+#ifx -C -traceback -fstack-protector -c  -I$macossrc_dir -I$matlab_version/extern/include -I$matlab_version/simulink/include -nologo -fpic -fpp -132 -gen-interfaces -fp-model strict -fno-omit-frame-pointer -D__amd64 -module $macossrc_dir/SMACOS_OBJS/Linux-x86_64  -DGMI_SVN_REV="''" -DGMI_DATE="'2024-01-18'"  -DMX_COMPAT_32 -O2 -xHOST  "GMI.F"
 
-ifx -C -traceback -fstack-protector -c  -I/home/lmarchen/MACOS/work/git_macos/macos-develop2/macos_f90 -I/usr/local/MATLAB/R2023b/extern/include -I/usr/local/MATLAB/R2023b/simulink/include -nologo -fpic -fpp -132 -gen-interfaces -fp-model strict -fno-omit-frame-pointer -D__amd64 -module /home/lmarchen/MACOS/work/git_macos/macos-develop2/macos_f90/SMACOS_OBJS/Linux-x86_64  -DGMI_SVN_REV="''" -DGMI_DATE="'2024-01-18'"  -DMX_COMPAT_32 -O2 -xHOST  "GMI.F"
+#ifx -C -traceback -fstack-protector -c  -I$macossrc_dir -I$matlab_version/extern/include -I$matlab_version/simulink/include -nologo -fpic -fpp -132 -gen-interfaces -fp-model strict -fno-omit-frame-pointer -D__amd64 -module $macossrc_dir/SMACOS_OBJS/Linux-x86_64  -DGMI_SVN_REV="''" -DGMI_DATE="'2024-01-18'"  -DMX_COMPAT_32 -O2 -xHOST  "GMIG.F"
 
-ifx -C -traceback -fstack-protector -c  -I/home/lmarchen/MACOS/work/git_macos/macos-develop2/macos_f90 -I/usr/local/MATLAB/R2023b/extern/include -I/usr/local/MATLAB/R2023b/simulink/include -nologo -fpic -fpp -132 -gen-interfaces -fp-model strict -fno-omit-frame-pointer -D__amd64 -module /home/lmarchen/MACOS/work/git_macos/macos-develop2/macos_f90/SMACOS_OBJS/Linux-x86_64  -DGMI_SVN_REV="''" -DGMI_DATE="'2024-01-18'"  -DMX_COMPAT_32 -O2 -xHOST  "GMIG.F"
-
-ifx -C -traceback -fstack-protector -O -shared-intel -shared -Wl,--version-script,/usr/local/MATLAB/R2023b/extern/lib/glnxa64/fexport.map  -Wl,--no-undefined -o  "GMI.mexa64"  GMI.o GMIG.o   -Wl,-rpath-link,/usr/local/MATLAB/R2023b/bin/glnxa64 -L/usr/local/MATLAB/R2023b/bin/glnxa64  -l:libmx.so -l:libmex.so -lmat -L/opt/intel-14.0.0/oneapi/compiler/2023.1.0/linux/compiler/lib/intel64 -lirc -lm -lstdc++  /home/lmarchen/MACOS/work/git_macos/macos-develop2/macos_f90/SMACOS_OBJS/Linux-x86_64/smacos_lib.a
+#ifx -C -traceback -fstack-protector -O -shared-intel -shared -Wl,--version-script,$matlab_version/extern/lib/glnxa64/fexport.map  -Wl,--no-undefined -o  "GMI.mexa64"  GMI.o GMIG.o   -Wl,-rpath-link,$matlab_version/bin/glnxa64 -L$matlab_version/bin/glnxa64  -l:libmx.so -l:libmex.so -lmat -L/opt/intel-14.0.0/oneapi/compiler/2023.1.0/linux/compiler/lib/intel64 -lirc -lm -lstdc++  $macossrc_dir/SMACOS_OBJS/Linux-x86_64/smacos_lib.a
 
 
 


### PR DESCRIPTION
I made changes that allow to compile on any directory using the linux box "marchen". If setup of Matlab and Intel compiler change user can change a couple of lines in makefile_all.sh and run to compile. There is no longer a need for user to change the Make files. The only detail is that GMI can only be compiled with Matlab 2013a because the commands to compile with any version of Matlab have issues when using global variables in place of path to Matlab, MACOS source code, and Intel compiler. We will need to resolve this issue either by adopting the new xml files from Matlab, or by fixing the issues with he GMI compilation commands we have been using to compile with any version of Matlab.